### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-rendering10 (9.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:59:16 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/libgz-rendering10-core-dev.install
+++ b/jammy/debian/libgz-rendering10-core-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-core-dev.install

--- a/jammy/debian/libgz-rendering10-dev.install
+++ b/jammy/debian/libgz-rendering10-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-dev.install

--- a/jammy/debian/libgz-rendering10-ogre1-dev.install
+++ b/jammy/debian/libgz-rendering10-ogre1-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre1-dev.install

--- a/jammy/debian/libgz-rendering10-ogre1.install
+++ b/jammy/debian/libgz-rendering10-ogre1.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre1.install

--- a/jammy/debian/libgz-rendering10-ogre2-dev.install
+++ b/jammy/debian/libgz-rendering10-ogre2-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre2-dev.install

--- a/jammy/debian/libgz-rendering10-ogre2.install
+++ b/jammy/debian/libgz-rendering10-ogre2.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre2.install

--- a/jammy/debian/libgz-rendering10-ogre2.install.install
+++ b/jammy/debian/libgz-rendering10-ogre2.install.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre2.install.install

--- a/jammy/debian/libgz-rendering10.install
+++ b/jammy/debian/libgz-rendering10.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.