### PR TITLE
Relocate .so files in lib (plugin) packages intead of in development packages

### DIFF
--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-rendering10 (10.0.0-2pre2~noble~noble) noble; urgency=medium
+
+  * gz-rendering10 10.0.0-2pre2~noble release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Thu, 04 Dec 2025 12:56:40 +0100
+
 gz-rendering10 (10.0.0-2pre1~noble) noble; urgency=medium
 
   * gz-rendering10 10.0.0-2pre1 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-rendering10 (10.0.0-2pre1~noble) noble; urgency=medium
+
+  * gz-rendering10 10.0.0-2pre1 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 03 Dec 2025 19:30:52 +0100
+
 gz-rendering10 (10.0.0-1~noble) noble; urgency=medium
 
   * gz-rendering10 10.0.0-1 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,8 +1,8 @@
-gz-rendering10 (10.0.0-2pre2~noble~noble) noble; urgency=medium
+gz-rendering10 (10.0.0-2pre3~noble) noble; urgency=medium
 
-  * gz-rendering10 10.0.0-2pre2~noble release
+  * gz-rendering10 10.0.0-2pre3 release
 
- -- Jose Luis Rivero <jrivero@osrfoundation.org>  Thu, 04 Dec 2025 12:56:40 +0100
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 08 Dec 2025 16:41:23 +0100
 
 gz-rendering10 (10.0.0-2pre1~noble) noble; urgency=medium
 

--- a/noble/debian/libgz-rendering10-core-dev.lintian-overrides
+++ b/noble/debian/libgz-rendering10-core-dev.lintian-overrides
@@ -1,0 +1,2 @@
+# This is a doxygen tag file, not an executable
+libgz-rendering10-core-dev: executable-not-elf-or-script [usr/share/gz/gz-rendering/gz-rendering.tag.xml]

--- a/noble/debian/libgz-rendering10-ogre1.lintian-overrides
+++ b/noble/debian/libgz-rendering10-ogre1.lintian-overrides
@@ -1,0 +1,4 @@
+# This is a plugin library package. The unversioned .so symlink is intentionally
+# included in the runtime package (not -dev) because plugins need to dlopen the
+# library by name without version suffix.
+libgz-rendering10-ogre1: link-to-shared-library-in-wrong-package * [usr/lib/*/libgz-rendering-ogre.so]

--- a/noble/debian/libgz-rendering10-ogre2.install.install
+++ b/noble/debian/libgz-rendering10-ogre2.install.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-rendering-ogre2.install.install

--- a/noble/debian/libgz-rendering10-ogre2.lintian-overrides
+++ b/noble/debian/libgz-rendering10-ogre2.lintian-overrides
@@ -1,0 +1,4 @@
+# This is a plugin library package. The unversioned .so symlink is intentionally
+# included in the runtime package (not -dev) because plugins need to dlopen the
+# library by name without version suffix.
+libgz-rendering10-ogre2: link-to-shared-library-in-wrong-package * [usr/lib/*/libgz-rendering-ogre2.so]

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -4,7 +4,7 @@ Section: science
 Priority: optional
 Build-Depends: cmake,
                doxygen,
-               pkg-config,
+               pkgconf,
                debhelper (>= 11),
                freeglut3-dev,
                libglew-dev,

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -93,6 +93,8 @@ Architecture: any
 Section: libdevel
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-rendering10-ogre1-dev (<< 10.0.0-2)
+Replaces: libgz-rendering10-ogre1-dev (<< 10.0.0-2)
 Description: Gazebo Rendering classes and functions for robot apps - Ogre1 lib
  Gazebo Rendering is a C++ library designed to provide an abstraction for
  different rendering engines. It offers unified APIs for creating 3D graphics
@@ -132,6 +134,8 @@ Architecture: any
 Section: libdevel
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-rendering10-ogre2-dev (<< 10.0.0-2)
+Replaces: libgz-rendering10-ogre2-dev (<< 10.0.0-2)
 Description: Gazebo Rendering classes and functions for robot apps - Development files
  Gazebo Rendering is a C++ library designed to provide an abstraction for
  different rendering engines. It offers unified APIs for creating 3D graphics

--- a/ubuntu/debian/libgz-rendering-core-dev.lintian-overrides
+++ b/ubuntu/debian/libgz-rendering-core-dev.lintian-overrides
@@ -1,0 +1,2 @@
+# This is a doxygen tag file, not an executable
+libgz-rendering10-core-dev: executable-not-elf-or-script [usr/share/gz/gz-rendering/gz-rendering.tag.xml]

--- a/ubuntu/debian/libgz-rendering-ogre1-dev.install
+++ b/ubuntu/debian/libgz-rendering-ogre1-dev.install
@@ -2,4 +2,3 @@ usr/include/*/rendering*/*/rendering/ogre/*
 usr/include/*/rendering*/*/rendering/ogre.hh
 usr/lib/*/pkgconfig/*-rendering-ogre.pc
 usr/lib/*/cmake/*-rendering-ogre/*
-usr/share/gz/*-rendering/ogre/*

--- a/ubuntu/debian/libgz-rendering-ogre1-dev.install
+++ b/ubuntu/debian/libgz-rendering-ogre1-dev.install
@@ -1,7 +1,5 @@
 usr/include/*/rendering*/*/rendering/ogre/*
 usr/include/*/rendering*/*/rendering/ogre.hh
-usr/lib/*/lib*-rendering-ogre.so
 usr/lib/*/pkgconfig/*-rendering-ogre.pc
 usr/lib/*/cmake/*-rendering-ogre/*
-usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre.so
 usr/share/gz/*-rendering/ogre/*

--- a/ubuntu/debian/libgz-rendering-ogre1.install
+++ b/ubuntu/debian/libgz-rendering-ogre1.install
@@ -1,2 +1,3 @@
 usr/lib/*/lib*-rendering-ogre.so*
 usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre.so*
+usr/share/gz/gz-rendering/ogre/media

--- a/ubuntu/debian/libgz-rendering-ogre1.install
+++ b/ubuntu/debian/libgz-rendering-ogre1.install
@@ -1,2 +1,2 @@
-usr/lib/*/lib*-rendering-ogre.so.*
-usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre.so.*
+usr/lib/*/lib*-rendering-ogre.so*
+usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre.so*

--- a/ubuntu/debian/libgz-rendering-ogre1.lintian-overrides
+++ b/ubuntu/debian/libgz-rendering-ogre1.lintian-overrides
@@ -1,0 +1,4 @@
+# This is a plugin library package. The unversioned .so symlink is intentionally
+# included in the runtime package (not -dev) because plugins need to dlopen the
+# library by name without version suffix.
+libgz-rendering10-ogre1: link-to-shared-library-in-wrong-package * [usr/lib/*/libgz-rendering-ogre.so]

--- a/ubuntu/debian/libgz-rendering-ogre2-dev.install
+++ b/ubuntu/debian/libgz-rendering-ogre2-dev.install
@@ -2,4 +2,3 @@ usr/include/*/rendering*/*/rendering/ogre2/*
 usr/include/*/rendering*/*/rendering/ogre2.hh
 usr/lib/*/pkgconfig/*-rendering-ogre2.pc
 usr/lib/*/cmake/*-rendering-ogre2/*
-usr/share/gz/*-rendering/ogre2/*

--- a/ubuntu/debian/libgz-rendering-ogre2-dev.install
+++ b/ubuntu/debian/libgz-rendering-ogre2-dev.install
@@ -1,7 +1,5 @@
 usr/include/*/rendering*/*/rendering/ogre2/*
 usr/include/*/rendering*/*/rendering/ogre2.hh
-usr/lib/*/lib*-rendering-ogre2.so
 usr/lib/*/pkgconfig/*-rendering-ogre2.pc
 usr/lib/*/cmake/*-rendering-ogre2/*
-usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre2*.so
 usr/share/gz/*-rendering/ogre2/*

--- a/ubuntu/debian/libgz-rendering-ogre2.install
+++ b/ubuntu/debian/libgz-rendering-ogre2.install
@@ -1,2 +1,2 @@
-usr/lib/*/lib*-rendering-ogre2.so.*
-usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre2*.so.*
+usr/lib/*/lib*-rendering-ogre2.so*
+usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre2*.so*

--- a/ubuntu/debian/libgz-rendering-ogre2.install
+++ b/ubuntu/debian/libgz-rendering-ogre2.install
@@ -1,2 +1,3 @@
 usr/lib/*/lib*-rendering-ogre2.so*
 usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre2*.so*
+usr/share/gz/gz-rendering/ogre2/media

--- a/ubuntu/debian/libgz-rendering-ogre2.install.install
+++ b/ubuntu/debian/libgz-rendering-ogre2.install.install
@@ -1,2 +1,0 @@
-usr/lib/*/lib*-rendering-ogre2.so.*
-usr/lib/*/*-rendering-[0-99]*/engine-plugins/lib*-rendering*-ogre2*.so.*

--- a/ubuntu/debian/libgz-rendering-ogre2.lintian-overrides
+++ b/ubuntu/debian/libgz-rendering-ogre2.lintian-overrides
@@ -1,0 +1,4 @@
+# This is a plugin library package. The unversioned .so symlink is intentionally
+# included in the runtime package (not -dev) because plugins need to dlopen the
+# library by name without version suffix.
+libgz-rendering10-ogre2: link-to-shared-library-in-wrong-package * [usr/lib/*/libgz-rendering-ogre2.so]

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -36,4 +36,4 @@ override_dh_auto_test:
 	true
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l/usr/lib/$(DEB_HOST_MULTIARCH)/OGRE-2.2 -l/usr/lib/$(DEB_HOST_MULTIARCH)/OGRE-NEXT
+	dh_shlibdeps -l/usr/lib/$(DEB_HOST_MULTIARCH)/OGRE-2.3 -l/usr/lib/$(DEB_HOST_MULTIARCH)/OGRE-NEXT

--- a/ubuntu/debian/source/lintian-overrides
+++ b/ubuntu/debian/source/lintian-overrides
@@ -1,0 +1,4 @@
+# These fonts are bundled with the OGRE media files and are required
+# for the rendering engine. They are duplicates of system fonts but
+# need to be present in the OGRE media directory for the engine to work.
+libgz-rendering10-ogre1-dev: duplicate-font-file * [usr/share/gz/gz-rendering/ogre/media/fonts/*]


### PR DESCRIPTION
A twin of https://github.com/gazebo-release/gz-physics9-release/pull/4, related to https://github.com/gazebo-release/gz-sim8-release/issues/8.

The installation of the different rendering plugin packages (libgz-rendering10-{ogre1|ogre2}) is not sufficient for gz server
to recognize them as being installed since it expects to find the files libgz-rendering-{engine}-plugin.so and those files were being shipped in the development packages (libgz-rendering10-{ogre1|ogre2}-dev).

This change moves the .so symlinks from the -dev packages to the runtime packages where they belong, ensuring plugins can be properly discovered at runtime without requiring the -dev packages to be installed.

The Breaks/Replaces fields ensure smooth upgrades from previous versions where the files were in the wrong package.